### PR TITLE
Add typography styling for images and figures in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,28 @@ module.exports = {
             p: {
               fontSize: '1rem',
               lineHeight: '1.6',
+              marginTop: '0.75em',
+              marginBottom: '0.75em',
+            },
+            img: {
+              marginTop: '1em',
+              marginBottom: '0.5em',
+              borderRadius: '0.375rem',
+              border: `1px solid ${theme('colors.gray.200')}`,
+              boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.03)',
+            },
+            figure: {
+              marginTop: '1em',
+              marginBottom: '1em',
+            },
+            'figure > img': {
+              marginTop: '0',
+              marginBottom: '0',
+            },
+            figcaption: {
+              marginTop: '0.375em',
+              fontSize: '0.875rem',
+              color: theme('colors.gray.500'),
             },
             'ul, ol': {
               fontSize: '1rem',
@@ -88,6 +110,12 @@ module.exports = {
             },
             'h1,h2,h3,h4,h5,h6': {
               color: theme('colors.gray.200'),
+            },
+            img: {
+              borderColor: theme('colors.gray.700'),
+            },
+            figcaption: {
+              color: theme('colors.gray.400'),
             },
           },
         },


### PR DESCRIPTION
## Summary
Enhanced the Tailwind CSS prose configuration to include comprehensive styling for images and figure elements, improving the visual presentation of embedded media in content.

## Key Changes
- **Paragraph spacing**: Added vertical margins (0.75em top/bottom) to `<p>` elements for better readability
- **Image styling**: 
  - Added margins, border radius, subtle border, and shadow to images
  - Images now have a light gray border (gray.200) with minimal shadow for depth
- **Figure elements**: 
  - Added margins to `<figure>` containers (1em top/bottom)
  - Nested images within figures have zero margins to prevent double spacing
- **Figure captions**: 
  - Styled `<figcaption>` with smaller font size (0.875rem) and gray color (gray.500)
  - Added top margin for spacing between image and caption
- **Dark mode support**: 
  - Updated image border color to gray.700 for dark mode
  - Updated figcaption color to gray.400 for dark mode contrast

## Implementation Details
All changes are made within the Tailwind prose plugin configuration, ensuring consistent styling across the entire content typography system. The styling follows semantic HTML best practices by properly handling the `<figure>` and `<figcaption>` relationship.